### PR TITLE
Remove IEquatable from IContext

### DIFF
--- a/Statecharts.NET.Core/Interfaces/Context.cs
+++ b/Statecharts.NET.Core/Interfaces/Context.cs
@@ -1,8 +1,6 @@
-﻿using System;
-
-namespace Statecharts.NET.Interfaces
+﻿namespace Statecharts.NET.Interfaces
 {
-    public interface IContext<TImplementing> : IEquatable<TImplementing>
+    public interface IContext<TImplementing>
     {
         TImplementing CopyDeep();
     }

--- a/Statecharts.NET.Core/Model/Target.cs
+++ b/Statecharts.NET.Core/Model/Target.cs
@@ -21,10 +21,12 @@ namespace Statecharts.NET.Model
             ChildStatenodesNames = childStatenodesNames;
         }
     }
-    public class SiblingTarget : RelativeTarget {
+    public class SiblingTarget : RelativeTarget
+    {
         public SiblingTarget(string statenodeName, params string[] childStatenodesNames) : base(statenodeName, childStatenodesNames) { }
     }
-    public class ChildTarget : RelativeTarget {
+    public class ChildTarget : RelativeTarget
+    {
         public ChildTarget(string statenodeName, params string[] childStatenodesNames) : base(statenodeName, childStatenodesNames) { }
     }
     public class SelfTarget : Target { }


### PR DESCRIPTION
`IEquatable`-Interface is no longer needed in `IContext`.